### PR TITLE
Output invalid BINDB row properly

### DIFF
--- a/bindb.go
+++ b/bindb.go
@@ -66,6 +66,10 @@ func LoadMain(db *DB, dbpath string, autofix func(string) string) error {
 		fields = strings.Split(line, "\t")
 		_, err = strconv.ParseInt(fields[0], 10, 32)
 		if err != nil || len(fields) < 12 {
+			if line == "bin	brand	bank	type	level	info	country	www	phone	address	city	zip" {
+				// Skip expected first line
+				continue
+			}
 			fmt.Printf("BINDB row is not valid: %s\n", line)
 			continue
 		}
@@ -93,6 +97,10 @@ func LoadMulti(db *DB, path string, autofix func(string) string) (err error) {
 		fields = strings.Split(line, "\t")
 		_, err = strconv.ParseInt(fields[0], 10, 32)
 		if err != nil || len(fields) < 12 {
+			if line == "bin	brand	bank	type	level	info	country	www	phone	address	city	zip" {
+				// Skip expected first line
+				continue
+			}
 			fmt.Printf("BINDB row is not valid: %s, fields number is %d\n", line, len(fields))
 			continue
 		}

--- a/bindb.go
+++ b/bindb.go
@@ -70,7 +70,7 @@ func LoadMain(db *DB, dbpath string, autofix func(string) string) error {
 				// Skip expected first line
 				continue
 			}
-			fmt.Printf("BINDB row is not valid: %s\n", line)
+			fmt.Printf("BINDB row is not valid: %s, fields number is %d\n", line, len(fields))
 			continue
 		}
 		db.Map[fields[0]] = BuildRecord(fields)


### PR DESCRIPTION
The scanner seems to always parse the first row, resulting in this bindb row invalid issue. I've did a check to skip the error check if the first row is as what is expected.

Additionally, I don't wish to 'pass' parsing the first row as an alternative as the format may change in future...

The change is not costly for sure.

![image](https://user-images.githubusercontent.com/1703663/216738023-1b295540-4740-418e-ba75-4227acaedda0.png)
